### PR TITLE
refactor: replace <div> with <main> for semantic structure in page co…

### DIFF
--- a/src/app/(app)/stats/page.tsx
+++ b/src/app/(app)/stats/page.tsx
@@ -88,7 +88,7 @@ export default async function StatsPage() {
     <>
       <SiteHeader />
 
-      <div className="max-w-screen overflow-x-hidden">
+      <main className="max-w-screen overflow-x-hidden">
         <div className="mx-auto px-4 md:max-w-4xl">
           <Header />
           <Pattern />
@@ -177,7 +177,7 @@ export default async function StatsPage() {
 
           <SiteFooter />
         </div>
-      </div>
+      </main>
 
       <ScrollTop />
     </>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,7 +29,7 @@ export default function Page() {
 
       <SiteHeader />
 
-      <div className="max-w-screen overflow-x-hidden">
+      <main className="max-w-screen overflow-x-hidden">
         <div className="mx-auto px-4 md:max-w-4xl">
           <Header />
           <Pattern />
@@ -66,7 +66,7 @@ export default function Page() {
 
           <SiteFooter />
         </div>
-      </div>
+      </main>
 
       {/* <QuickActions /> */}
 

--- a/src/features/profile/components/header.tsx
+++ b/src/features/profile/components/header.tsx
@@ -61,10 +61,13 @@ export function Header() {
 
         <div className="flex flex-1 flex-col">
           <div className="flex grow items-end mask-r-from-60% pb-1 pl-4">
-            <div className="line-clamp-1 font-mono text-xs text-zinc-400 select-none dark:text-muted-foreground">
+            <div
+              aria-hidden="true"
+              className="line-clamp-1 font-mono text-xs text-zinc-500 select-none dark:text-zinc-400"
+            >
               {"text-3xl "}
-              <span className="inline dark:hidden">text-zinc-4000</span>
-              <span className="hidden dark:inline">text-zinc-700</span>
+              <span className="inline dark:hidden">text-zinc-500</span>
+              <span className="hidden dark:inline">text-zinc-400</span>
               {" font-medium"}
             </div>
           </div>


### PR DESCRIPTION
…mponents

- Updated the main layout in `page.tsx` and `stats/page.tsx` to use <main> instead of <div> for better semantic HTML and accessibility.